### PR TITLE
`max_tokens` not necessary

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "Togetherai",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "A simple plugin to integrate Together AI SaaS",
     "author_name": "valentimarco",
     "author_url": "https://www.linkedin.com/in/valentimarco21/",

--- a/togetherai.py
+++ b/togetherai.py
@@ -5,12 +5,11 @@ from datetime import datetime, date
 from cat.factory.llm import LLMSettings
 from langchain_together import ChatTogether
 
-class TogetherAIConfig(LLMSettings):
+class TogetherAIConfig004(LLMSettings):
     together_api_key: str
     together_api_base: str = "https://api.together.xyz/v1"
     model_name: str = "meta-llama/Llama-3-8b-chat-hf"
     temperature: float = 0.7
-    max_tokens: int = 4096
     streaming: bool = True
 
     _pyclass: Type = ChatTogether
@@ -26,5 +25,5 @@ class TogetherAIConfig(LLMSettings):
 
 @hook
 def factory_allowed_llms(allowed, cat) -> List:
-    allowed.append(TogetherAIConfig)
+    allowed.append(TogetherAIConfig004)
     return allowed


### PR DESCRIPTION
- took away `max_tokens` param (not required anymore)
- changed name of the adapter to `TogetherAIConfig004` to avoid old settings in metadata.json to conflict with new plugin version
- bumped version to `0.0.4`
- tested with all latest llama3 versions

P.S.: sometimes there are rate limit errors for llama3 405B, I guess because too many people are using it (tried both free and paid account)